### PR TITLE
Disable `FORTIFY_SOURCE` when not optimizing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,10 @@ cpp = meson.get_compiler('cpp')
 add_project_arguments(get_option('cxxflags'), language : 'cpp')
 add_project_link_arguments(get_option('ldflags'), language: 'cpp')
 
+if(get_option('optimization') == '0')
+  add_project_arguments('-U_FORTIFY_SOURCE',language:['cpp','c'])
+  message('Disabling FORTIFY_SOURCE as optimization is set to 0')
+endif
 
 cmake = import('cmake')
 pkg = import('pkgconfig')


### PR DESCRIPTION
Matches current flags:
https://github.com/NixOS/nix/blob/9cf991f421b20a2c753df1f93730ddc8ddf7af6c/Makefile#L30-L32

Signed-off-by: Pamplemousse <xav.maso@gmail.com>