### PR TITLE
Compiling without Boehm works

### DIFF
--- a/dependencies/bdw-gc/meson.build
+++ b/dependencies/bdw-gc/meson.build
@@ -2,14 +2,9 @@
 #============================================================================
 
 
-## FIXME !! Boehm is supposed to be an optional dependency
-## but is currently required for libexpr & libcmd to compile
-## correctly. 
-
-
 # Look for Boehm garbage collector, an optional dependency
 #--------------------------------------------------
-if get_option('with_gc')
+if get_option('enable_gc')
     gc_dep = dependency('bdw-gc')
 else
     gc_dep = dependency('', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -41,7 +41,7 @@ option(
 #============================================================================
 
 option(
-    'with_gc',
+    'enable_gc',
     type : 'boolean',
     value : 'true',
     description : 'Build nix with Boehm garbage collector')


### PR DESCRIPTION
  * seems to have been fixed by NixOS/nix#4947
  * change option name to match current `./configure` option
  * tested by succesfully running `meson compile nixexpr`

Signed-off-by: Pamplemousse <xav.maso@gmail.com>