### PR TITLE
Missing options for documentation generation

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,10 +62,22 @@ option(
 # misc
 #============================================================================
 option(
-    'disable_doc_gen',
+    'doc_generate',
     type : 'boolean',
     value : 'false',
-    description : 'disable documentation generation')
+    description : 'Build the documentation and manpages')
+
+option(
+    'mandir',
+    type : 'string',
+    value : 'share/man',
+    description : 'Man pages location path')
+
+option(
+    'docdir',
+    type : 'string',
+    value : 'share/doc',
+    description : 'Documentation location path')
 
 option(
     'build_shared_libs',


### PR DESCRIPTION
Forgot to add the relevant options in #10 ...
Name changed to match current options (see https://github.com/NixOS/nix/blob/master/Makefile.config.in).